### PR TITLE
fix(NGWebSocket): support WebSocket Secure URLs

### DIFF
--- a/src/ngSocket.js
+++ b/src/ngSocket.js
@@ -2,7 +2,7 @@ angular.module('ngSocket', []).
   factory('ngWebSocket', ['$rootScope', '$window', '$q',
     function ($rootScope, $window, $q) {
       var NGWebSocket = function (url) {
-        var match = /ws?:\/\//.exec(url);
+        var match = /ws{1,2}?:\/\//.exec(url);
 
         if (!match) {
           throw new Error('Invalid url provided');

--- a/test/ngSocket.spec.js
+++ b/test/ngSocket.spec.js
@@ -35,6 +35,12 @@ describe('ngSocket', function () {
       expect(spy).toHaveBeenCalledWith(url);
     });
 
+    it('should attempt connecting to a secure socket if provided a valid URL', function () {
+      var spy = spyOn($window, 'WebSocket');
+      var url = 'wss://foo/bar';
+      var ws = ngWebSocket(url);
+      expect(spy).toHaveBeenCalledWith(url);
+    });
 
     it('should return a promise when connecting', function () {
       var ws = ngWebSocket('ws://foo/bar');


### PR DESCRIPTION
Adds support for WebSocket Secure URLs, which uses the "wss://" prefix.
