### PR TITLE
fix(ngWebSocket): Add annotation for minified ngWebSocket factory

### DIFF
--- a/src/ngSocket.js
+++ b/src/ngSocket.js
@@ -76,7 +76,7 @@ angular.module('ngSocket', []).
       return new $window.WebSocket(url);
     };
   }]).
-  factory('ngWebSocket', [function () {
+  factory('ngWebSocket', ['ngWebSocketBackend', function (ngWebSocketBackend) {
       var NGWebSocket = function (url) {
         this.url = url;
         this.sendQueue = [];


### PR DESCRIPTION
The ngWebSocket factory depends on the ngWebSocketBackend service, but doesn't declare this dependency in the annotation array. This commit fixes that problem.

Closes #7.
