### PR TITLE
fix(bower.json): correct license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "javascript",
     "websockets"
   ],
-  "license": "MIT",
+  "license": "Apache 2",
   "ignore": [
     "src/",
     "**/.*",


### PR DESCRIPTION
previously MIT now Apache 2
https://github.com/angular/ngSocket/blob/master/LICENSE

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/ngsocket/28)

<!-- Reviewable:end -->
